### PR TITLE
Improve speed when turning lights/switches on and off

### DIFF
--- a/openmotics/__init__.py
+++ b/openmotics/__init__.py
@@ -10,6 +10,7 @@ import asyncio
 import logging
 import socket
 from datetime import timedelta
+from typing import Optional
 
 import voluptuous as vol
 
@@ -218,10 +219,10 @@ class OpenMoticsHub(object):
             _LOGGER.error(e)
             return None
 
-    #@Throttle(MIN_TIME_BETWEEN_UPDATES)
-    def update(self):
+    @Throttle(MIN_TIME_BETWEEN_UPDATES)
+    def update(self) -> Optional[bool]:
         """Update the status op the Openmotics modules."""
-        self.force_update()
+        return self.force_update()
 
     def force_update(self) -> bool:
         """Function to force an update of the modules.

--- a/openmotics/light.py
+++ b/openmotics/light.py
@@ -18,6 +18,7 @@ DEPENDENCIES = ['openmotics']
 
 BRIGHTNESS_SCALE_UP = 2.55
 BRIGHTNESS_SCALE_DOWN = 0.3925
+NOT_IN_USE = "NOT_IN_USE"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +60,11 @@ class OpenMoticsLight(Light):
         self.update()
 
     @property
+    def hidden(self):
+        """Return True if the entity should be hidden from UIs."""
+        return self._name == NOT_IN_USE
+
+    @property
     def supported_features(self):
         """Flag supported features."""
         """Check if the light's module is a Dimmer, return brightness as a supported feature."""
@@ -66,7 +72,7 @@ class OpenMoticsLight(Light):
             return SUPPORT_BRIGHTNESS
         else:
             return 0
-  
+
     @property
     def name(self):
         """Return the name of the light."""

--- a/openmotics/light.py
+++ b/openmotics/light.py
@@ -100,18 +100,17 @@ class OpenMoticsLight(Light):
             brightness = int(kwargs[ATTR_BRIGHTNESS] * BRIGHTNESS_SCALE_DOWN)
             self._dimmer = brightness
         if self.hub.set_output(self._id, True, self._dimmer, self._timer):
-            self.hub.force_update()
             self._state = True
 
     def turn_off(self, **kwargs):
         """Turn devicee off."""
         if self.hub.set_output(self._id, False, None, None):
-            self.hub.force_update()
             self._state = False
 
     def update(self):
         """Update the state of the light."""
-        self.hub.update()
+        if not self.hub.update() and self._state is not None:
+            return
         output_statuses = self._hass.data[OM_OUTPUT_STATUS]
         if not output_statuses:
             _LOGGER.error('No responce form the controller')

--- a/openmotics/switch.py
+++ b/openmotics/switch.py
@@ -74,18 +74,17 @@ class OpenMoticsSwitch(SwitchDevice):
     def turn_on(self, **kwargs):
         """Turn device on."""
         if self.hub.set_output(self._id, True, self._dimmer, self._timer):
-            self.hub.force_update()
             self._state = True
 
     def turn_off(self, **kwargs):
         """Turn devicee off."""
         if self.hub.set_output(self._id, False, None, None):
-            self.hub.force_update()
             self._state = False
 
     def update(self):
         """Update the state of the switch."""
-        self.hub.update()
+        if not self.hub.update() and self._state is not None:
+            return
         output_statuses = self._hass.data[OM_OUTPUT_STATUS]
         if not output_statuses:
             _LOGGER.error('No responce form the controller')


### PR DESCRIPTION
The current implementation forces an update of the state of all devices after an on/off command for a light or switch.
This implementation changes this by using the a throttled update call as well as using the return value of the on/off api call.
This drastically improves the on/off speed of a single switch or light but is most noticeable when creating automations which use multiple devices.